### PR TITLE
Remove scope classes and replace them with scope methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Thus in the above set of examples, invoking `authorize` executes the `get` metho
 
 The `authorize` method acts more as a true/false guard. On the other hand the `policy_scope` method returns a 'scoped' version of a model. For example, if you have a page with all posts, you might want to let an admin see all of them but restrict the ones staff users see. This is where you'd want to use `policy_scope` instead of `authorize`.
 
-To do so, you need to first have a `Scope` class. Scopes are classes that help you return 'scoped' versions of models. You can define a scope as:
+To do so, you need to define a `scope` method in your policy.
 
 ```python
 from flask_pundit.application_policy import ApplicationPolicy
@@ -83,22 +83,16 @@ from flask_pundit.application_policy import ApplicationPolicy
 class PostPolicy(ApplicationPolicy):
         def get(self):
                 return self.user == 'admin' and self.record.id == 1
+
+
+        def scope(self):
+                if self.user == 'admin':
+                        return record.all()
+                return record.filter_by(author='staff')
         
-        class Scope():
-                def __init__(self, user, scope):
-                        self.user = user
-                        self.scope = scope
-
-                def resolve(self):
-                        if self.user == 'admin':
-                                return scope.all()
-                        return scope.filter_by(author='staff')
 ```
-The `Scope` class for a model should always be an inner class of the corresponding Policy class. The constructor takes 2 arguments - the user (exactly like in the Policy class) and a `scope` which is the model you want to return a subset of.
 
-Instead of writing the constructor every time you need a scope you could also just inherit from `ApplicationPolicy.Scope`.
-
-When you call the `policy_scope(model)` with a model class (it doesn't make sense to pass an object here), the `resolve` method gets called.
+When you call the `policy_scope(model)` with a model class (it doesn't make sense to pass an object here), the `scope` method gets called.
 
 ``` python
 from app import pundit

--- a/flask_pundit/__init__.py
+++ b/flask_pundit/__init__.py
@@ -28,36 +28,19 @@ def verify_policy_scoped(func):
         pundit = getattr(flask.current_app, 'extensions', {})\
             .get('flask_pundit')
         stack_top = pundit._get_stack_top()
-        stack_top.pundit_callbacks = getattr(stack_top, 'pundit_callbacks', [])
-        stack_top.pundit_callbacks.append(pundit._verify_policy_scoped)
-        response = ''
-        try:
-            response = func(*args, **kwargs)
-            return response
-        except:
-            stack_top.pundit_callbacks.pop()
-            raise
-    return inner
-
-
-def _process_verification_hooks(response):
-    pundit = getattr(flask.current_app, 'extensions', {}).get('flask_pundit')
-    stack_top = pundit._get_stack_top()
-    callbacks = getattr(stack_top, 'pundit_callbacks', [])
-    while len(callbacks) > 0:
-        call = callbacks.pop()
-        if call() is False:
+        response = func(*args, **kwargs)
+        if not getattr(stack_top, 'policy_scope_called', False):
             raise RuntimeError('''
-            Failed to call authorize/policy_scope method
+            Failed to call policy_scope method
             but used verification decorator''')
-    return response
+        return response
+    return inner
 
 
 class FlaskPundit(object):
 
-    SCOPE_ACTION = 'resolve'
+    SCOPE_ACTION = 'scope'
     POLICY_SUFFIX = 'Policy'
-    SCOPE_SUFFIX = 'Scope'
 
     def __init__(self, app=None, policies_path='policies'):
         self.app = app
@@ -99,11 +82,11 @@ class FlaskPundit(object):
         """
         current_user = user or self._get_current_user()
         action = FlaskPundit.SCOPE_ACTION
-        scope_clazz = self._get_scope_clazz(scope)
+        policy_clazz = self._get_policy_clazz(scope)
 
         self._get_stack_top().policy_scope_called = True
         return getattr(
-            scope_clazz(current_user, scope), action
+            policy_clazz(current_user, scope), action
         )(*args, **kwargs)
 
     def _verify_authorized(self):
@@ -147,10 +130,6 @@ class FlaskPundit(object):
         record_class = getattr(record, '__class__', None)
         if record_class is not None:
             return record_class
-
-    def _get_scope_clazz(self, record):
-        policy_clazz = self._get_policy_clazz(record)
-        return getattr(policy_clazz, FlaskPundit.SCOPE_SUFFIX)
 
     def _get_policy_module(self, model_name):
         dasherized_model_name = dasherized_name(model_name)

--- a/flask_pundit/application_policy.py
+++ b/flask_pundit/application_policy.py
@@ -3,11 +3,3 @@ class ApplicationPolicy:
     def __init__(self, user, record):
         self.user = user
         self.record = record
-
-    class Scope:
-        def __init__(self, user, scope):
-            self.user = user
-            self.scope = scope
-
-        def resolve(self, *args, **kwargs):
-            pass

--- a/tests/policies/commenting.py
+++ b/tests/policies/commenting.py
@@ -5,8 +5,7 @@ class CommentingPolicy(ApplicationPolicy):
     def get(self):
         return self.user.get('role') == 'admin'
 
-    class Scope(ApplicationPolicy.Scope):
-        def resolve(self):
-            if self.user.get('role') == 'admin':
-                return ['Hello']
-            return ['World']
+    def scope(self):
+        if self.user.get('role') == 'admin':
+            return ['Hello']
+        return ['World']

--- a/tests/policies/post.py
+++ b/tests/policies/post.py
@@ -10,8 +10,7 @@ class PostPolicy(ApplicationPolicy):
     def create(self):
         return self.user.get('role') == 'admin'
 
-    class Scope(ApplicationPolicy.Scope):
-        def resolve(self):
-            if self.user.get('role') == 'admin':
-                return [1, 2]
-            return [3, 4]
+    def scope(self):
+        if self.user.get('role') == 'admin':
+            return [1, 2]
+        return [3, 4]

--- a/tests/test_flask_pundit.py
+++ b/tests/test_flask_pundit.py
@@ -52,11 +52,10 @@ class TestFlaskPundit(TestCase):
         assert_raises(AttributeError, self.pundit.authorize, record, 'update')
 
     @patch('flask_pundit.flask')
-    def test_policy_scope_triggers_resolve_action(self, flask):
+    def test_policy_scope_triggers_scope_action(self, flask):
         flask.configure_mock(**(self.get_flask_defaults()))
-        scope_class_instance = Mock(resolve=lambda: [1, 2, 3])
-        scope_class = Mock(return_value=scope_class_instance)
-        policy_class = Mock(Scope=scope_class)
+        policy_class_instance = Mock(scope=lambda: [1, 2, 3])
+        policy_class = Mock(return_value=policy_class_instance)
 
         self.pundit._get_policy_clazz = Mock(return_value=policy_class)
         eq_(self.pundit.policy_scope(Mock()), [1, 2, 3])


### PR DESCRIPTION
Scope classes are just unnecessary complexity and can be achieved by a method.

I still like the idea of having a `policy_scope`method vs just calling `authorize` with an action as `scope`. This is primarily because its more indicative that this is 'different' behaviour.