### PR TITLE
Unpin Flask requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 requirements = [
-    'Flask==1.0.2',
+    'Flask>=1.0.2,<2',
 ]
 
 setup(


### PR DESCRIPTION
As Flask releases bug fixes (e.g. 1.0.3), new features (e.g. 1.1.0), etc. that do not break compatibility (according to [semver](https://semver.org)) it would be nice for Pundit to not complain about using newer releases.  I've updated setup.py to reflect this.