### PR TITLE
docs: Fix simple typo, mdoel -> model

### DIFF
--- a/flask_pundit/__init__.py
+++ b/flask_pundit/__init__.py
@@ -91,7 +91,7 @@ class FlaskPundit(object):
 
     def policy_scope(self, scope, user=None, *args, **kwargs):
         """ Call this method from within a resource or
-        a route to return a scoped version of a mdoel
+        a route to return a scoped version of a model
         For example, blog posts only viewable by the admin's staff.
         """
         current_user = user or self._get_current_user()


### PR DESCRIPTION
There is a small typo in flask_pundit/__init__.py.

Should read `model` rather than `mdoel`.

